### PR TITLE
Create/config Vite to Pages Action

### DIFF
--- a/.github/workflows/vite-deploy.yml
+++ b/.github/workflows/vite-deploy.yml
@@ -1,0 +1,59 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy Vite.js site to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ['master']
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets the GITHUB_TOKEN permissions to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v3.0.6
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm install
+      - name: Vite Build
+        run: npm run build --base=$VITE_BASE_URL
+        env:
+          VITE_BASE_URL: "/website/"
+      - name: Upload GH Pages artifact
+        uses: actions/upload-pages-artifact@v2  
+        with:
+          # Upload dist folder
+          path: './dist'
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
Adds a GitHub Action that builds with Vite and deploys to GitHub Pages for this repository. 

A draft for now because I'm not 100% sure yet whether the deployment is working properly -- I need to do one more test to verify that my action is working as expected. Result is currently just a blank page with the metadata: https://humbledeer.github.io/vzbot3d-devin-website